### PR TITLE
Timecode semicolon delimiter addition

### DIFF
--- a/index.js
+++ b/index.js
@@ -1187,7 +1187,7 @@ class instance extends instance_skel {
 	}
 
 	processTimecode(fullTimecode){
-		let timecode = fullTimecode.split(':')
+		let timecode = fullTimecode.split(/:|;/)
 		this.setVariable('TC_hours', timecode[0]);
 		this.setVariable('TC_min', timecode[1]);
 		this.setVariable('TC_sec', timecode[2]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aja-kipro",
-	"version": "2.0.11",
+	"version": "2.0.12",
 	"legacy": [
 		"kipro"
 	],


### PR DESCRIPTION
Minor change to allow for ";" as a delimiter in time code. This will close issue #16 